### PR TITLE
Bugfix: if-pre-up.d/netns

### DIFF
--- a/if-pre-up.d/netns
+++ b/if-pre-up.d/netns
@@ -5,7 +5,7 @@ set -e
 if [ -n "${IF_NETNS}" ]
 then
   # Create netns if it doesn't already exist, and bring up the loopback
-  if ! (ip netns list | grep -qx ${IF_NETNS})
+  if ! (ip netns list | cut -d ' ' -f 1 | grep -qx ${IF_NETNS})
   then
     mkdir -p /etc/netns/$IF_NETNS/network/{if-down.d,if-post-down.d,if-pre-up.d,if-up.d}
     if [ ! -f /etc/netns/$IF_NETNS/network/interfaces ]; then


### PR DESCRIPTION
On debian Bullseye, ifupdown is adding extra information to the netns list.
This patch will extract only the namespace name from the list and  ignore the extra information